### PR TITLE
Add ops total panel, theme overhaul, and aircraft orientation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,10 @@
 # Agent Notes
 
 ## Adding a theme preset
-- Define `menu_theme`, `game_bg`, `game_fg`, `game_muted`, `hub_color`,
-  `good_spoke`, `bad_spoke`, `bar_A`, `bar_B`, `bar_C`, `bar_D`.
-- Optionally include `default_airframe_colorset`; never set `ac_colors` directly.
-- Ensure `game_fg` vs `game_bg` contrast ≥ 4.5:1.
-- Bar colors A–D must be visually distinct.
-- Do not override a user's chosen airframe color map when applying presets.
+- Provide all core tokens: `menu_theme`, `game_bg`, `game_fg`, `game_muted`,
+  `hub_color`, `good_spoke`, `bad_spoke`, `bar_A`, `bar_B`, `bar_C`, `bar_D`.
+- Ensure contrast between `game_fg` and `game_bg` is ≥ 4.5:1 for HUD text.
+- Bars A/B/C/D must be perceptually distinct.
+- Never override a user's selected airframe color map (`ac_colors`).
 - Renderer derives `panel_bg`, `panel_btn`, `panel_btn_fg` and
   `overlay_backdrop_rgba` from `game_bg` + `hub_color`; avoid hardcoded greys.

--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -19,6 +19,16 @@ Presets supply core tokens and may specify a `default_airframe_colorset` for
 first‑run defaults. Switching presets does not modify the user's chosen
 airframe colors.
 
+## Visualization
+
+- Right-side fullscreen panel modes:
+  - `ops_total_number` (default) shows a large running total of OFFLOAD ops.
+  - `ops_total_sparkline` plots a sparkline of recent totals.
+  - `per_spoke` shows legacy per-spoke bars.
+- Aircraft glyphs can optionally rotate toward their current destination when
+  `orient_aircraft` is enabled. Both interactive and headless renderers share
+  this behavior.
+
 ## Recording paths and offline render
 
 - Live recording is disabled until the user selects an existing output folder.

--- a/README.txt
+++ b/README.txt
@@ -20,9 +20,21 @@ refuse to start until these paths are set. Live sessions write PNG frames or
 `session.mp4` (if `imageio` + `imageio-ffmpeg` are installed). Offline renders
 now run in a background process with a progress strip and a "Cancel" button.
 
-The **Visualization** tab includes a *Recording Overlays* section controlling
-what appears in live recordings: HUD, debug overlay, fullscreen panels, REC
-watermark, timestamps, frame indices, scale percentage and aircraft labels.
+Right Panel Views
+-----------------
+The fullscreen right panel defaults to a large **Total Ops** number. Switch
+between the number, a rolling sparkline or legacy per-spoke bars via the
+*Right Panel View* menu on the **Visualization** tab.
+
+Aircraft Heading
+----------------
+Enable *Orient Aircraft Toward Destination* on the **Visualization** tab to
+rotate aircraft icons toward their current destination. Disable it to keep all
+triangles upright.
+
+Below this are *Recording Overlays* controls for what appears in live
+recordings: HUD, debug overlay, fullscreen panels, REC watermark, timestamps,
+frame indices, scale percentage and aircraft labels.
 
 Other controls:
 - Sliders now have digital readouts (Entry fields) — type values directly or drag the slider.
@@ -41,5 +53,5 @@ Visualizer keys:
 Notes:
 - The ops counter is uncapped now.
 - HOME/END jumps removed.
-- In fullscreen, the left panel shows operational spokes and supply totals/averages; the right panel shows per‑spoke ops counts (number of OFFLOADs serviced at each spoke).
+- In fullscreen, the left panel shows operational spokes and supply totals/averages. The right panel can show a running Total Ops number, a Total Ops sparkline, or per‑spoke ops counts.
 - If MP4 assembly isn't available (no imageio), you'll still get PNG frames you can stitch with another tool.


### PR DESCRIPTION
## Summary
- Add right-panel view modes including Total Ops number and sparkline
- Apply unified theme tokens across UI and replace hardcoded greys
- Support heading-aware aircraft orientation with visualization toggle
## Testing
- `python -m py_compile cargo_sim_with_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_689bc66295b883319e3a3c86e9d9842e