### PR TITLE
feat: expand config and recording performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,14 @@
 - Never override a user's selected airframe color map (`ac_colors`).
 - Renderer derives `panel_bg`, `panel_btn`, `panel_btn_fg` and
   `overlay_backdrop_rgba` from `game_bg` + `hub_color`; avoid hardcoded greys.
+
+## Coding
+- Follow existing snake_case style and keep functions compact.
+- Persist new `SimConfig` fields via `to_json` / `from_json` and bump
+  `CONFIG_VERSION` when changing schema.
+- Prefer non-blocking design for recording; respect queue limits and dropping
+  behaviour controlled by config.
+
+## Tests
+- `python -m py_compile cargo_sim_with_gui.py`
+- `python cargo_sim_with_gui.py --offline-render` (may fail if pygame missing).

--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -27,11 +27,22 @@ airframe colors.
   - `per_spoke` shows legacy per-spoke bars.
 - Aircraft glyphs can optionally rotate toward their current destination when
   `orient_aircraft` is enabled. Both interactive and headless renderers share
-  this behavior.
+  this behavior. When parked at the hub, glyphs are forced to face north.
 
 ## Recording paths and offline render
 
 - Live recording is disabled until the user selects an existing output folder.
+- The recording subsystem uses a producer/consumer queue with an optional
+  asynchronous writer thread. When the queue fills, frames may be dropped rather
+  than blocking the GUI. The HUD shows dropped counts.
 - Offline rendering requires an explicit file path; the render button spawns a
-  background process and shows progress with Cancel/Reveal buttons.
+  background process and shows progress with Cancel/Reveal buttons. Polling
+  cadence is configurable.
 - All saved paths are normalized to absolute form in the config file.
+
+## Advanced Decision Making & Gameplay
+
+- `SimConfig.adm` holds fairness cooldowns, target days-of-supply for A/B,
+  an emergency preemption toggle and a deterministic seed.
+- `SimConfig.gameplay` contains realism toggles, leg time radius ranges and
+  fleet optimization weights grouped under the *Gameplay* tab.

--- a/README.txt
+++ b/README.txt
@@ -16,9 +16,18 @@ theme.
 
 Recording requires explicit destinations. The **Recording** tab lets you select
 a folder for live captures and a file path for offline renders; recording will
-refuse to start until these paths are set. Live sessions write PNG frames or
-`session.mp4` (if `imageio` + `imageio-ffmpeg` are installed). Offline renders
-now run in a background process with a progress strip and a "Cancel" button.
+refuse to start until these paths are set. Live sessions write `session_*.mp4`
+or PNG frames using an asynchronous producer/consumer queue. If the queue
+fills, frames are dropped rather than blocking the UI and the HUD shows
+"REC n (dropped=x)". Offline renders run in a background process with progress
+and a *Cancel* button.
+
+Advanced Decision Making & Gameplay
+-----------------------------------
+The **Scheduling** tab now includes an *Advanced Decision Making* group for
+tuning routing behavior (fairness cooldowns, target days-of-supply and a
+deterministic seed). A new **Gameplay** tab exposes toggles for *Realism* and
+*Fleet Optimization* features with adjustable weights.
 
 Right Panel Views
 -----------------
@@ -30,7 +39,7 @@ Aircraft Heading
 ----------------
 Enable *Orient Aircraft Toward Destination* on the **Visualization** tab to
 rotate aircraft icons toward their current destination. Disable it to keep all
-triangles upright.
+triangles upright. While parked at the hub, aircraft always face due north.
 
 Below this are *Recording Overlays* controls for what appears in live
 recordings: HUD, debug overlay, fullscreen panels, REC watermark, timestamps,


### PR DESCRIPTION
## Summary
- add config_version and new recording, ADM, gameplay config fields
- use async recording queue with optional frame dropping
- orient parked aircraft north and expose ADM/Game tabs with toggles

## Testing
- `python -m py_compile cargo_sim_with_gui.py`
- `python cargo_sim_with_gui.py --offline-render` *(fails: pygame is required for offline rendering)*

------
https://chatgpt.com/codex/tasks/task_e_689be11eb9588331ae9ba27224fe1f72