### PR TITLE
feat: theme helpers and period slider improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@
 - Never override a user's selected airframe color map (`ac_colors`).
 - Renderer derives `panel_bg`, `panel_btn`, `panel_btn_fg` and
   `overlay_backdrop_rgba` from `game_bg` + `hub_color`; avoid hardcoded greys.
+- Cyber theme must use only green on black; bad spokes pulse with a dashed ring.
+
+## Overlay stats
+- When adding recording overlay stats, draw them in both interactive and
+  headless renderers.
 
 ## Coding
 - Follow existing snake_case style and keep functions compact.

--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -11,6 +11,8 @@ Core theme tokens are stored in `ThemeConfig`:
 At runtime the renderer derives:
 - `panel_bg`, `panel_btn`, `panel_btn_fg`
 - `overlay_backdrop_rgba`
+from core tokens using a shared `hex_to_rgb` and `blend(a,b,t)` helper so all
+surfaces stay on theme.
 
 Both the interactive `Renderer` and offline `Headless` renderer compute and use
 these values so offline frames match the on‑screen simulation.
@@ -26,8 +28,9 @@ airframe colors.
   - `ops_total_sparkline` plots a sparkline of recent totals.
   - `per_spoke` shows legacy per-spoke bars.
 - Aircraft glyphs can optionally rotate toward their current destination when
-  `orient_aircraft` is enabled. Both interactive and headless renderers share
-  this behavior. When parked at the hub, glyphs are forced to face north.
+  `orient_aircraft` is enabled. On departure from the hub the heading smoothly
+  interpolates from north to the leg heading over the first ~15 % of the
+  segment. When parked at the hub, glyphs are forced to face north.
 
 ## Recording paths and offline render
 
@@ -39,6 +42,9 @@ airframe colors.
   background process and shows progress with Cancel/Reveal buttons. Polling
   cadence is configurable.
 - All saved paths are normalized to absolute form in the config file.
+The overlay pipeline is: HUD/overlays are drawn onto the Pygame surface → the
+resulting frame is scaled if requested → the writer thread/process encodes the
+frame to MP4 or PNG.
 
 ## Advanced Decision Making & Gameplay
 

--- a/README.txt
+++ b/README.txt
@@ -5,6 +5,15 @@ CargoSim — Control GUI + Visualizer (Themed, Recording, Offline Render)
 Run:
     python cargo_sim_with_gui.py
 
+Highlights
+---------
+- **Themes:** ten distinct presets with derived tokens; Cyber is pure green on
+  jet black.
+- **Recording Overlays:** presets plus optional statistics for live and offline
+  captures.
+- **Seconds/Period:** slider now ranges from 2.00 s down to 0.05 s with a live
+  numeric readout.
+
 Themes and Recording
 --------------------
 The **Theme** tab offers ten presets (Classic Light/Dark, Cyber, GitHub


### PR DESCRIPTION
## Summary
- consolidate color helpers and refresh Cyber theme with green-on-black palette
- add pulsing warning effect for Cyber spokes and smooth north-to-leg rotation
- add seconds/period slider with fine range and page note helpers

## Testing
- `python -m py_compile cargo_sim_with_gui.py`
- `python cargo_sim_with_gui.py --offline-render` *(fails: pygame is required for offline rendering)*

------
https://chatgpt.com/codex/tasks/task_e_689be80131988331aa7ca7abe4bc6d9a