### PR TITLE
Unify ops capability and fullscreen defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ CargoSim models a hub-and-spoke airlift network with daily AM/PM cadence. Aircra
 - Periods alternate AM/PM; arrivals apply at the next period.
 - **Ops gate:** A+B+C+D must all be >0 for an op to run.
 - Only ops consume C and D. PM consumption requires A>0 and B>0 and reduces only A and B.
+- A spoke is operational (green) only if it has A, B, C, and D on hand now (arrivals become usable next period).
+- Each op consumes one unit of C and D at that spoke; A and B gate PM consumption and ops eligibility but are not consumed by the op itself.
 
 ## Features
 - Five themes: GitHub Dark, Classic Light, Solarized Light, Night Ops, Cyber (green/black).

--- a/cargosim/__main__.py
+++ b/cargosim/__main__.py
@@ -26,10 +26,11 @@ def main(argv=None) -> int:
     parser.add_argument("--headless", action="store_true")
     parser.add_argument("--periods", type=int, default=4)
     parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--windowed", action="store_true")
     args = parser.parse_args(argv)
     if args.headless:
         return run_headless(args.periods, args.seed)
-    gui_main()
+    gui_main(force_windowed=args.windowed)
     return 0
 
 

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -11,7 +11,7 @@ import cargosim.__main__ as cm
 def test_python_m_cargosim(monkeypatch):
     called = SimpleNamespace(count=0)
 
-    def fake_main():
+    def fake_main(**kwargs):
         called.count += 1
     monkeypatch.setattr(cargo_sim, "main", fake_main)
     monkeypatch.setattr(cm, "gui_main", fake_main)

--- a/tests/test_fullscreen.py
+++ b/tests/test_fullscreen.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pygame
+
+from cargo_sim import LogisticsSim, SimConfig, Renderer
+
+
+def test_fullscreen_default():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    cfg = SimConfig()
+    sim = LogisticsSim(cfg)
+    rnd = Renderer(sim)
+    assert rnd.fullscreen
+    assert rnd.screen.get_flags() & pygame.FULLSCREEN
+    pygame.quit()

--- a/tests/test_ops_gate.py
+++ b/tests/test_ops_gate.py
@@ -2,7 +2,11 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from cargo_sim import LogisticsSim, SimConfig
+
+import pygame
+
+from cargo_sim import LogisticsSim, SimConfig, Renderer
+
 
 def make_sim():
     cfg = SimConfig(periods=2, a_days=1, b_days=1)
@@ -11,32 +15,42 @@ def make_sim():
     return sim
 
 
-def test_op_occurs_and_consumes_cd():
+def test_ops_gate_syncs_ui():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
     sim = make_sim()
-    sim.stock[0] = [1, 1, 1, 1]
+    for i in range(5):
+        sim.stock[i] = [1, 1, 1, 1]
+    missing = [[0,1,1,1], [1,0,1,1], [1,1,0,1], [1,1,1,0], [0,0,0,0]]
+    for idx, vec in enumerate(missing, start=5):
+        sim.stock[idx] = vec
+    for s in range(sim.M):
+        sim.op[s] = sim.can_run_op(s)
+    rnd = Renderer(sim)
+    rnd.draw_spokes()
+    assert sim.ops_count() == 5
+    good = rnd.good_spoke_col
+    bad = rnd.bad_spoke_col
+    for i, (x, y) in enumerate(rnd.spoke_pos):
+        col = rnd.screen.get_at((int(x), int(y)))[:3]
+        if i < 5:
+            assert col == good
+        else:
+            assert col == bad
+    pygame.quit()
+
+
+def test_ops_consumes_CD_only():
+    sim = make_sim()
+    sim.stock[0] = [2, 2, 2, 2]
     assert sim.run_op(0)
-    assert sim.stock[0] == [1, 1, 0, 0]
-    assert sim.ops_by_spoke[0] == 1
+    assert sim.stock[0] == [2, 2, 1, 1]
 
 
-def test_op_blocked_when_missing():
+def test_arrival_timing():
     sim = make_sim()
-    sim.stock[0] = [1, 0, 1, 1]
+    sim.stock[0] = [1, 1, 0, 0]
+    sim.arrivals_next[0].append([0, 0, 1, 1])
     assert not sim.run_op(0)
-    assert sim.stock[0] == [1, 0, 1, 1]
-    assert sim.ops_by_spoke[0] == 0
-
-
-def test_pm_consumption_requires_a_and_b():
-    sim = make_sim()
-    sim.stock[0] = [0, 1, 0, 0]
-    sim.t = 1
     sim.step_period()
-    assert sim.stock[0] == [0, 1, 0, 0]
-
-    sim2 = make_sim()
-    sim2.stock[0] = [2, 3, 1, 1]
-    sim2.t = 1
-    sim2.step_period()
-    assert sim2.stock[0][0] == 1 and sim2.stock[0][1] == 2
-    assert sim2.stock[0][2] == 1 and sim2.stock[0][3] == 1
+    assert sim.stock[0] == [1, 1, 1, 1]
+    assert sim.run_op(0)


### PR DESCRIPTION
## Summary
- Centralize operations gating via `is_ops_capable` and apply it across scheduler, HUD and spoke rendering
- Consume only C/D for ops with invariants and integrity badge
- Launch fullscreen by default with `--windowed` override and persistent config
- Document ops gating and consumption rules

## Testing
- `python -m py_compile cargo_sim.py`
- `python cargo_sim.py --offline-render` *(fails: No video mode has been set)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ce0b542ec8331a0a8ac2bb511bb70