### PR TITLE
Fix headless render and enforce ops gating

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -45,6 +45,8 @@ names (Cobalt, Signal Orange, Cyber Lime, Cerulean, Royal Magenta).
 - Offline rendering requires an explicit file path; the render button spawns a
   background process and shows progress with Cancel/Reveal buttons. Polling
   cadence is configurable.
+- Headless rendering creates a tiny hidden display (SDL dummy driver) so text
+  surfaces can `convert_alpha` without an on‑screen window.
 - All saved paths are normalized to absolute form in the config file.
 The overlay pipeline is: HUD/overlays are drawn onto the Pygame surface → the
 resulting frame is scaled if requested → the writer thread/process encodes the

--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ CargoSim models a hub-and-spoke airlift network with daily AM/PM cadence. Aircra
 
 ## Core Concepts
 - Periods alternate AM/PM; arrivals apply at the next period.
-- **Ops gate:** A+B+C+D must all be >0 for an op to run.
-- Only ops consume C and D. PM consumption requires A>0 and B>0 and reduces only A and B.
-- A spoke is operational (green) only if it has A, B, C, and D on hand now (arrivals become usable next period).
-- Each op consumes one unit of C and D at that spoke; A and B gate PM consumption and ops eligibility but are not consumed by the op itself.
+- Ops can run only when a spoke has A, B, C, and D on hand now (arrivals are usable next period). Each op consumes one unit of C and D; A and B gate ops/PM but are not consumed by the op.
 
 ## Features
 - Five themes: GitHub Dark, Classic Light, Solarized Light, Night Ops, Cyber (green/black).


### PR DESCRIPTION
## Summary
- Guard text rendering so convert_alpha runs only when a display exists
- Default interactive renderer to fullscreen double-buffered mode and persist toggles
- Enforce ops gating with immediate C/D consumption and update docs

## Testing
- `python -m py_compile cargo_sim.py`
- `python cargo_sim.py --offline-render`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cea38420483318441741cb36aa66f