### PR TITLE
Fix headless text rendering and default fullscreen

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -46,6 +46,9 @@ names (Cobalt, Signal Orange, Cyber Lime, Cerulean, Royal Magenta).
   background process and shows progress with Cancel/Reveal buttons. Polling
   cadence is configurable.
 - All saved paths are normalized to absolute form in the config file.
+- Headless offline rendering creates a hidden 1×1 display using the SDL "dummy"
+  driver so that surface conversions like `convert_alpha()` succeed without a
+  visible window.
 The overlay pipeline is: HUD/overlays are drawn onto the Pygame surface → the
 resulting frame is scaled if requested → the writer thread/process encodes the
 frame to MP4 or PNG.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ CargoSim models a hub-and-spoke airlift network with daily AM/PM cadence. Aircra
 
 ## Core Concepts
 - Periods alternate AM/PM; arrivals apply at the next period.
-- **Ops gate:** A+B+C+D must all be >0 for an op to run.
-- Only ops consume C and D. PM consumption requires A>0 and B>0 and reduces only A and B.
-- A spoke is operational (green) only if it has A, B, C, and D on hand now (arrivals become usable next period).
-- Each op consumes one unit of C and D at that spoke; A and B gate PM consumption and ops eligibility but are not consumed by the op itself.
+- Ops can run only when a spoke has A, B, C, and D on hand now (arrivals are usable next period). Each op consumes one unit of C and D; A and B gate ops/PM but are not consumed by the op.
 
 ## Features
 - Five themes: GitHub Dark, Classic Light, Solarized Light, Night Ops, Cyber (green/black).


### PR DESCRIPTION
## Summary
- Guard text surface conversion when no display exists and set up hidden display for headless offline rendering
- Launch interactive renderer in fullscreen by default with a persistent fullscreen/windowed toggle
- Document ops gating and hidden headless display

## Testing
- `python -m py_compile cargo_sim.py`
- `python cargo_sim.py --offline-render` *(fails: pygame is required for offline rendering)*


------
https://chatgpt.com/codex/tasks/task_e_689cea38420483318441741cb36aa66f