### PR TITLE
Add safe-area layout and fullscreen recording defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Key highlights: `SPACE` pause, `←/→` step, `+/-` speed, `R` reset, `D` debug
 
 ## Recording
 Live recording writes MP4 or PNG when a folder is set. Offline rendering requires a file path and runs atomically with progress and cancel options.
+By default, recordings capture the fullscreen resolution with all HUD and side panels visible.
 ## Advanced Decision Making
 Fairness cooldown, A/B target DoS, emergency A preempt, deterministic RNG seed.
 


### PR DESCRIPTION
## Summary
- Recompute layout using safe-area padding and percentage-based side rails
- Default recordings to fullscreen resolution with visualization panels
- Track fullscreen size and support flexible offline render resolutions

## Testing
- `python -m py_compile cargo_sim.py`
- `python cargo_sim.py --offline-render` *(fails: pygame is required for offline rendering)*

------
https://chatgpt.com/codex/tasks/task_e_689d03a9a0cc83318fe5a8d74698db07